### PR TITLE
Fix import of ifcopenshell.util.unit with Python <3.10 #4520

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/unit.py
@@ -668,7 +668,7 @@ def format_length(
 
 
 def is_attr_type(
-    content_type: ifcopenshell.ifcopenshell_wrapper.named_type | ifcopenshell.ifcopenshell_wrapper.type_declaration,
+    content_type: Union[ifcopenshell.ifcopenshell_wrapper.named_type, ifcopenshell.ifcopenshell_wrapper.type_declaration],
     ifc_unit_type_name: str,
 ) -> Union[ifcopenshell.ifcopenshell_wrapper.type_declaration, None]:
     cur_decl = content_type


### PR DESCRIPTION
This one line fix does it for me. I suppose it is compatible with Python > 3.9.